### PR TITLE
Dont charge world startup

### DIFF
--- a/src/main/java/me/hsgamer/morefoworld/WorldUtil.java
+++ b/src/main/java/me/hsgamer/morefoworld/WorldUtil.java
@@ -39,6 +39,7 @@ import org.bukkit.WorldCreator;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.generator.CraftWorldInfo;
+import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.generator.BiomeProvider;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.generator.WorldInfo;
@@ -222,6 +223,10 @@ public final class WorldUtil {
         }
 
         internal.setSpawnSettings(true, true);
+
+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addWorld(internal);
+
+        Bukkit.getPluginManager().callEvent(new WorldLoadEvent(internal.getWorld())); // Call Event
 
         return Feedback.SUCCESS.toFeedbackWorld(internal.getWorld());
     }

--- a/src/main/java/me/hsgamer/morefoworld/WorldUtil.java
+++ b/src/main/java/me/hsgamer/morefoworld/WorldUtil.java
@@ -224,6 +224,7 @@ public final class WorldUtil {
 
         internal.setSpawnSettings(true, true);
 
+        console.prepareLevels(internal.getChunkSource().chunkMap.progressListener, internal);
         io.papermc.paper.threadedregions.RegionizedServer.getInstance().addWorld(internal);
 
         Bukkit.getPluginManager().callEvent(new WorldLoadEvent(internal.getWorld())); // Call Event

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,7 +2,7 @@ name: '${name}'
 version: '${version}'
 main: me.hsgamer.morefoworld.MoreFoWorld
 api-version: '${apiVersion}'
-load: STARTUP
+load: POSTWORLD
 authors: [HSGamer]
 description: '${description}'
 folia-supported: true


### PR DESCRIPTION
On the Paper API, we can clearly see that the creation of the world should not be put at the start of the server. In addition to that, it breaks the World Generators which load just after the plugin.